### PR TITLE
Address rubocop v0.28.0 offenses found in cookbook v0.0.1

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,15 +1,15 @@
-name             "sar"
-maintainer       "Philip Hutchins"
-maintainer_email "flipture@gmail.com"
-license          "Apache 2.0"
-description      "Installs/Configures sar"
+name 'sar'
+maintainer 'Philip Hutchins'
+maintainer_email 'flipture@gmail.com'
+license 'Apache 2.0'
+description 'Installs/Configures sar'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.0.1"
+version '0.0.2'
 
-%w{ ubuntu debian redhat centos scientific amazon fedora }.each do |os|
+%w(ubuntu debian redhat centos scientific amazon fedora).each do |os|
   supports os
 end
 
-%w{ yum apt }.each do |ckbk|
+%w(yum apt).each do |ckbk|
   recommends ckbk
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,11 +7,11 @@ template '/etc/default/sysstat' do
   mode 0644
   owner 'root'
   group 'root'
-  variables({
-    :sar_enabled => node['sar']['enabled'],
-    :sa1_options => node['sar']['sa1_options'],
-    :sa2_options => node['sar']['sa2_options']
-  })
+  variables(
+    sar_enabled: node['sar']['enabled'],
+    sa1_options: node['sar']['sa1_options'],
+    sa2_options: node['sar']['sa2_options']
+  )
 end
 
 template '/etc/cron.d/sysstat' do
@@ -19,7 +19,7 @@ template '/etc/cron.d/sysstat' do
   mode 0644
   owner 'root'
   group 'root'
-  variables({
-    :run_every_minutes => node['sar']['cron']['run_every_minutes']
-  })
+  variables(
+    run_every_minutes: node['sar']['cron']['run_every_minutes']
+  )
 end


### PR DESCRIPTION
Philip,

At my company they encourage us to run the Ruby linting tool called "rubocop" (which comes with the ChefDK) on our cookbook Ruby files. In my limited experiencae with it, it's kind of a hassle to use because it's quite sensitive (it'll pick up tons of things that "ruby -c <file>" doesn't care about). But I like it because it helps me write Ruby in what I'm hoping is a more standard and readable way.

As a practice for me as a newcomer to the Chef community, I propose to address these straightforward "rubocop offenses" in a pull request.

Linc Abbey

```
chef-sar (linc)$ pwd
/Users/linc/chef/chef-repo/cookbooks/chef-sar

chef-sar (linc)$ rubocop -n
warning: parser/current is loading parser/ruby21, which recognizes
warning: 2.1.7-compliant syntax, but you are running 2.1.5.
Inspecting 3 files
C.C

Offenses:

metadata.rb:1:5: C: Put one space between the method name and the first argument.
name             "sar"
    ^^^^^^^^^^^^^
metadata.rb:1:18: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
name             "sar"
                 ^^^^^
metadata.rb:2:11: C: Put one space between the method name and the first argument.
maintainer       "Philip Hutchins"
          ^^^^^^^
metadata.rb:2:18: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
maintainer       "Philip Hutchins"
                 ^^^^^^^^^^^^^^^^^
metadata.rb:3:18: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
maintainer_email "flipture@gmail.com"
                 ^^^^^^^^^^^^^^^^^^^^
metadata.rb:4:8: C: Put one space between the method name and the first argument.
license          "Apache 2.0"
       ^^^^^^^^^^
metadata.rb:4:18: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
license          "Apache 2.0"
                 ^^^^^^^^^^^^
metadata.rb:5:12: C: Put one space between the method name and the first argument.
description      "Installs/Configures sar"
           ^^^^^^
metadata.rb:5:18: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
description      "Installs/Configures sar"
                 ^^^^^^^^^^^^^^^^^^^^^^^^^
metadata.rb:7:8: C: Put one space between the method name and the first argument.
version          "0.0.1"
       ^^^^^^^^^^
metadata.rb:7:18: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
version          "0.0.1"
                 ^^^^^^^
metadata.rb:9:1: C: %w-literals should be delimited by ( and )
%w{ ubuntu debian redhat centos scientific amazon fedora }.each do |os|
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
metadata.rb:13:1: C: %w-literals should be delimited by ( and )
%w{ yum apt }.each do |ckbk|
^^^^^^^^^^^^^
recipes/default.rb:10:13: C: Redundant curly braces around a hash parameter.
  variables({
            ^
recipes/default.rb:11:5: C: Use the new Ruby 1.9 hash syntax.
    :sar_enabled => node['sar']['enabled'],
    ^^^^^^^^^^^^^^^
recipes/default.rb:11:5: C: Use 2 spaces for indentation in a hash, relative to the first position after the preceding left parenthesis.
    :sar_enabled => node['sar']['enabled'],
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
recipes/default.rb:12:5: C: Use the new Ruby 1.9 hash syntax.
    :sa1_options => node['sar']['sa1_options'],
    ^^^^^^^^^^^^^^^
recipes/default.rb:13:5: C: Use the new Ruby 1.9 hash syntax.
    :sa2_options => node['sar']['sa2_options']
    ^^^^^^^^^^^^^^^
recipes/default.rb:14:3: C: Indent the right brace the same as the first position after the preceding left parenthesis.
  })
  ^
recipes/default.rb:22:13: C: Redundant curly braces around a hash parameter.
  variables({
            ^
recipes/default.rb:23:5: C: Use the new Ruby 1.9 hash syntax.
    :run_every_minutes => node['sar']['cron']['run_every_minutes']
    ^^^^^^^^^^^^^^^^^^^^^
recipes/default.rb:23:5: C: Use 2 spaces for indentation in a hash, relative to the first position after the preceding left parenthesis.
    :run_every_minutes => node['sar']['cron']['run_every_minutes']
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
recipes/default.rb:24:3: C: Indent the right brace the same as the first position after the preceding left parenthesis.
  })
  ^

3 files inspected, 23 offenses detected
```
