### PR TITLE
Add ChefSpec unit test for package install and config file creation

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,15 +1,15 @@
-name             "sar"
-maintainer       "Philip Hutchins"
-maintainer_email "flipture@gmail.com"
-license          "Apache 2.0"
-description      "Installs/Configures sar"
+name 'sar'
+maintainer 'Philip Hutchins'
+maintainer_email 'flipture@gmail.com'
+license 'Apache 2.0'
+description 'Installs/Configures sar'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.0.1"
+version '0.0.2'
 
-%w{ ubuntu debian redhat centos scientific amazon fedora }.each do |os|
+%w(ubuntu debian redhat centos scientific amazon fedora).each do |os|
   supports os
 end
 
-%w{ yum apt }.each do |ckbk|
+%w(yum apt).each do |ckbk|
   recommends ckbk
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,11 +7,11 @@ template '/etc/default/sysstat' do
   mode 0644
   owner 'root'
   group 'root'
-  variables({
-    :sar_enabled => node['sar']['enabled'],
-    :sa1_options => node['sar']['sa1_options'],
-    :sa2_options => node['sar']['sa2_options']
-  })
+  variables(
+    sar_enabled: node['sar']['enabled'],
+    sa1_options: node['sar']['sa1_options'],
+    sa2_options: node['sar']['sa2_options']
+  )
 end
 
 template '/etc/cron.d/sysstat' do
@@ -19,7 +19,7 @@ template '/etc/cron.d/sysstat' do
   mode 0644
   owner 'root'
   group 'root'
-  variables({
-    :run_every_minutes => node['sar']['cron']['run_every_minutes']
-  })
+  variables(
+    run_every_minutes: node['sar']['cron']['run_every_minutes']
+  )
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,1 @@
+require 'chefspec'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -4,6 +4,7 @@
 #
 # Copyright (c) 2015, Lincoln Abbey <linc.abbey@gmail.com>
 
+$LOAD_PATH << File.expand_path(File.dirname(__FILE__) + '/../..')
 require 'spec_helper'
 
 describe 'sar::default' do
@@ -13,8 +14,24 @@ describe 'sar::default' do
       runner.converge(described_recipe)
     end
 
-    it 'converges successfully' do
-      chef_run # This should not raise an error
+    it 'installs the sysstat package' do
+      expect(chef_run).to install_package('sysstat')
+    end
+
+    it 'creates config file /etc/default/sysstat' do
+      expect(chef_run).to create_template('/etc/default/sysstat').with(
+        user: 'root',
+        group: 'root',
+        mode: 0644
+      )
+    end
+
+    it 'creates config file /etc/cron.d/sysstat' do
+      expect(chef_run).to create_template('/etc/cron.d/sysstat').with(
+        user: 'root',
+        group: 'root',
+        mode: 0644
+      )
     end
   end
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -1,0 +1,22 @@
+#
+# Cookbook Name:: sar
+# Spec:: default
+#
+# Copyright (c) 2015, Lincoln Abbey <linc.abbey@gmail.com>
+
+require 'spec_helper'
+
+describe 'sar::default' do
+  context 'When all attributes are default, on an unspecied platform' do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new
+      runner.converge(described_recipe)
+    end
+
+    it 'converges successfully' do
+      chef_run # This should not raise an error
+    end
+  end
+end
+
+# EOF

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: sar
 # Spec:: default
 #
-# Copyright (c) 2015, Lincoln Abbey <linc.abbey@gmail.com>
+# Copyright (c) 2015, Philip Hutchins <flipture@gmail.com>
 
 $LOAD_PATH << File.expand_path(File.dirname(__FILE__) + '/../..')
 require 'spec_helper'


### PR DESCRIPTION
Philip,

I think I read somewhere that you shouldn't write Chef cookbook unit tests that simply verify that a recipe does what you told it to do. I interpreted that person -- can't remember where I read it -- to be saying, if you do "package <package>" in your recipe, don't write a unit test the confirms that your recipe installs <package>, because in doing so, you're just testing that Chef does what it's supposed to do. And Chef itself has plenty of tests of itself already.

I'm new to Chef, but I don't look at it like that. I like the idea of a unit test's being "executable requirements" for a recipe, verifying that the recipe does everything it's supposed to. That way, if in future somebody modifies the recipe and accidentally deletes some aspect of it that's important, the unit test will catch it.

Anyway, I put together a unit test for the sar cookbook's default recipe that simply checks that it does in fact install sysstat and create each of two config files. It's no big deal now, but if/as the cookbook gets expanded to do more (support more platforms), I'm thinking it might be useful.

I'd appreciate any tips or criticisms you might have about it, so I can learn to write ChefSpec tests better.

Thanks,

--Linc Abbey
